### PR TITLE
Support fixed point numbers

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -50,17 +50,11 @@ jobs:
     - name: Build (all features)
       run: cargo build --verbose --release --all-features
 
-    - name: Test (no_std)
-      run: cargo test --verbose
-    - name: Test (std)
-      run: cargo test --verbose --features="std"
-    - name: Test (fixed, no_std)
-      run: cargo test --verbose --features="fixed"
-    - name: Test (float, no_std)
-      run: cargo test --verbose --features="float"
     - name: Test (fixed, std)
       run: cargo test --verbose --features="fixed,std"
     - name: Test (float, std)
       run: cargo test --verbose --features="float,std"
-    - name: Test (all features)
-      run: cargo test --verbose --all-features
+    - name: Test Release (fixed, std)
+      run: cargo test --verbose --release --features="fixed,std"
+    - name: Test Release (float, std)
+      run: cargo test --verbose --release --features="float,std"

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -16,13 +16,51 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Lint (no_std)
+
+    - name: Formatting
+      run: cargo fmt --check
+
+    - name: Clippy (no_std)
       run: cargo clippy --verbose
-    - name: Lint (all features)
+    - name: Clippy (std)
+      run: cargo clippy --verbose --features="std"
+    - name: Clippy (fixed, no_std)
+      run: cargo clippy --verbose --features="fixed"
+    - name: Clippy (float, no_std)
+      run: cargo clippy --verbose --features="float"
+    - name: Clippy (fixed, std)
+      run: cargo clippy --verbose --features="fixed,std"
+    - name: Clippy (float, std)
+      run: cargo clippy --verbose --features="float,std"
+    - name: Clippy (all features)
       run: cargo clippy --verbose --all-features
+
     - name: Build (no_std)
       run: cargo build --verbose --release
+    - name: Build (std)
+      run: cargo build --verbose --release --features="std"
+    - name: Build (fixed, no_std)
+      run: cargo build --verbose --release --features="fixed"
+    - name: Build (float, no_std)
+      run: cargo build --verbose --release --features="float"
+    - name: Build (fixed, std)
+      run: cargo build --verbose --release --features="fixed,std"
+    - name: Build (float, std)
+      run: cargo build --verbose --release --features="float,std"
     - name: Build (all features)
-      run: cargo build --verbose --release --features std
-    - name: Run tests
+      run: cargo build --verbose --release --all-features
+
+    - name: Test (no_std)
+      run: cargo test --verbose
+    - name: Test (std)
+      run: cargo test --verbose --features="std"
+    - name: Test (fixed, no_std)
+      run: cargo test --verbose --features="fixed"
+    - name: Test (float, no_std)
+      run: cargo test --verbose --features="float"
+    - name: Test (fixed, std)
+      run: cargo test --verbose --features="fixed,std"
+    - name: Test (float, std)
+      run: cargo test --verbose --features="float,std"
+    - name: Test (all features)
       run: cargo test --verbose --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,28 @@
 [package]
 name = "guv"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Jesse C. Grillo <jgrillo@protonmail.com>"]
 description = "A PID Controller"
 license = "Apache-2.0"
 repository = "https://github.com/jgrillo/guv"
 readme = "README.md"
 edition = "2021"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+rust-version = "1.60"
 
 [features]
 default = []
 std = []
+fixed = ["dep:fixed", "dep:cordic"]
+float = ["dep:num-traits"]
 
 [dependencies]
-num-traits = "0.2"
-thiserror = "1.0"
+fixed = { version = "1", optional = true }
+cordic = { version = "0.1", optional = true }
+num-traits = { version = "0.2", features = ["libm"], optional = true }
 
 [dev-dependencies]
+arbitrary = "1"
+fixed = { version = "1", features = ["arbitrary"] }
 plotters = "0.3"
-proptest = "1.0"
+proptest = "1"
+proptest-arbitrary-interop = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.60"
 [features]
 default = []
 std = []
-fixed = ["dep:fixed", "dep:cordic"]
+fixed = ["dep:num-traits", "dep:fixed", "dep:cordic"]
 float = ["dep:num-traits"]
 
 [dependencies]
@@ -22,7 +22,7 @@ num-traits = { version = "0.2", features = ["libm"], optional = true }
 
 [dev-dependencies]
 arbitrary = "1"
-fixed = { version = "1", features = ["arbitrary"] }
+fixed = { version = "1", features = ["arbitrary", "num-traits"] }
 num-traits = { version = "0.2", features = ["libm"]}
 plotters = "0.3"
 proptest = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ num-traits = { version = "0.2", features = ["libm"], optional = true }
 [dev-dependencies]
 arbitrary = "1"
 fixed = { version = "1", features = ["arbitrary"] }
+num-traits = { version = "0.2", features = ["libm"]}
 plotters = "0.3"
 proptest = "1"
 proptest-arbitrary-interop = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -474,8 +474,8 @@ where
 
 #[cfg(feature = "std")]
 pub mod std {
-    use std::time::SystemTimeError;
     use crate::PidControllerError;
+    use std::time::SystemTimeError;
 
     impl From<SystemTimeError> for PidControllerError {
         fn from(e: SystemTimeError) -> Self {
@@ -496,8 +496,8 @@ pub mod std {
 
     #[cfg(feature = "fixed")]
     pub mod fixed {
-        use std::time::SystemTime;
         use crate::{Number, PidControllerError};
+        use std::time::SystemTime;
 
         /// Compute the number of seconds that has elapsed between
         /// `last_update_time` and `measurement_time`. Returns a
@@ -509,26 +509,28 @@ pub mod std {
             last_update_time: SystemTime,
         ) -> Result<T, PidControllerError>
         where
-            T: Number
-            + fixed::traits::LosslessTryFrom<u64>
-            + fixed::traits::LosslessTryFrom<u32>,
+            T: Number + fixed::traits::LosslessTryFrom<u64> + fixed::traits::LosslessTryFrom<u32>,
         {
             let duration = measurement_time.duration_since(last_update_time)?;
 
-            Ok(T::lossless_try_from(duration.as_secs()).ok_or(PidControllerError::Numeric(
-                "duration's seconds part must be representable as T"
-            ))? + (T::lossless_try_from(duration.subsec_nanos()).ok_or(PidControllerError::Numeric(
-                "duration's nanoseconds part must be representable as T"
-            ))? / T::lossless_try_from(1_000_000_000_u32).ok_or(PidControllerError::Numeric(
-                "1_000_000_000 must be representable as T"
-            ))?))
+            Ok(
+                T::lossless_try_from(duration.as_secs()).ok_or(PidControllerError::Numeric(
+                    "duration's seconds part must be representable as T",
+                ))? + (T::lossless_try_from(duration.subsec_nanos()).ok_or(
+                    PidControllerError::Numeric(
+                        "duration's nanoseconds part must be representable as T",
+                    ),
+                )? / T::lossless_try_from(1_000_000_000_u32).ok_or(
+                    PidControllerError::Numeric("1_000_000_000 must be representable as T"),
+                )?),
+            )
         }
     }
 
     #[cfg(feature = "float")]
     pub mod real {
-        use std::time::SystemTime;
         use crate::{Number, PidControllerError};
+        use std::time::SystemTime;
 
         /// Compute the number of seconds that has elapsed between
         /// `last_update_time` and `measurement_time`. Returns a
@@ -544,13 +546,15 @@ pub mod std {
         {
             let duration = measurement_time.duration_since(last_update_time)?;
 
-            Ok(T::from_u64(duration.as_secs()).ok_or(PidControllerError::Numeric(
-                "duration's seconds part must be representable as T"
-            ))? + (T::from_u32(duration.subsec_nanos()).ok_or(PidControllerError::Numeric(
-                "duration's nanoseconds part must be representable as T"
-            ))? / T::from_u32(1_000_000_000_u32).ok_or(PidControllerError::Numeric(
-                "1_000_000_000 must be representable as T"
-            ))?))
+            Ok(
+                T::from_u64(duration.as_secs()).ok_or(PidControllerError::Numeric(
+                    "duration's seconds part must be representable as T",
+                ))? + (T::from_u32(duration.subsec_nanos()).ok_or(PidControllerError::Numeric(
+                    "duration's nanoseconds part must be representable as T",
+                ))? / T::from_u32(1_000_000_000_u32).ok_or(PidControllerError::Numeric(
+                    "1_000_000_000 must be representable as T",
+                ))?),
+            )
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,17 +2,13 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use core::{
-    fmt::{Debug, Display},
-    ops::{Add, Div, Mul, Neg, Sub},
-    result::Result,
-};
+use core::{fmt::Debug, ops::Neg, result::Result};
 
 /// This trait allows `PidController<T: Number>` to be defined abstractly over
 /// the underlying number type. Blanket implementations are (optionally)
 /// provided for the following types:
 /// \
-/// - `num_traits::real::Real + num_traits::FloatConst` if compiled with feature
+/// - `num_traits::float::Float + num_traits::FloatConst` if compiled with feature
 ///   `"float"`
 /// \
 /// - `fixed::traits::FixedSigned + cordic::CordicNumber` if compiled with
@@ -20,17 +16,11 @@ use core::{
 /// \
 /// **N.B.:** while these features aren't mutually exclusive--the crate will
 /// compile with them both activated--you'll have to supply your `PidController`
-/// with a type `T` which implements both `num_traits::real::Real` and
+/// with a type `T` which implements both `num_traits::float::Float` and
 /// `fixed::traits::FixedSigned`. If you accomplish this, please let me know!
 pub trait Number
 where
-    Self: Copy
-        + PartialOrd
-        + Div<Output = Self>
-        + Mul<Output = Self>
-        + Neg<Output = Self>
-        + Sub<Output = Self>
-        + Add<Output = Self>,
+    Self: Copy + PartialOrd + Neg<Output = Self>,
 {
     fn zero() -> Self;
 
@@ -38,9 +28,21 @@ where
 
     fn epsilon() -> Self;
 
+    fn max_value() -> Self;
+
     fn pi() -> Self;
 
     fn abs(&self) -> Self;
+
+    fn clamp(&self, min: Self, max: Self) -> Self;
+
+    fn safe_add(&self, rhs: Self) -> Self;
+
+    fn safe_sub(&self, rhs: Self) -> Self;
+
+    fn safe_mul(&self, rhs: Self) -> Self;
+
+    fn safe_div(&self, rhs: Self) -> Self;
 
     fn sin(&self) -> Self;
 
@@ -51,7 +53,7 @@ where
 #[cfg(all(feature = "float", not(feature = "fixed")))]
 impl<T> Number for T
 where
-    T: num_traits::real::Real + num_traits::FloatConst,
+    T: num_traits::float::Float + num_traits::FloatConst,
 {
     fn zero() -> T {
         T::zero()
@@ -65,12 +67,74 @@ where
         T::epsilon()
     }
 
+    fn max_value() -> T {
+        Self::one().safe_div(Self::epsilon())
+    }
+
     fn pi() -> T {
         T::PI()
     }
 
     fn abs(&self) -> T {
         T::abs(*self)
+    }
+
+    fn clamp(&self, min: T, max: T) -> T {
+        if self < &min {
+            min
+        } else if self > &max {
+            max
+        } else {
+            *self
+        }
+    }
+
+    fn safe_add(&self, rhs: Self) -> Self {
+        let max = Self::max_value();
+        let res = *self + rhs;
+        if <Self as num_traits::float::Float>::is_finite(res) {
+            res.clamp(-max, max)
+        } else {
+            max
+        }
+    }
+
+    fn safe_sub(&self, rhs: Self) -> Self {
+        let max = Self::max_value();
+        let res = *self - rhs;
+        if <Self as num_traits::float::Float>::is_finite(res) {
+            res.clamp(-max, max)
+        } else {
+            -max
+        }
+    }
+
+    fn safe_mul(&self, rhs: Self) -> Self {
+        let max = Self::max_value();
+        let res = *self * rhs;
+        if <Self as num_traits::float::Float>::is_finite(res) {
+            res.clamp(-max, max)
+        } else {
+            max
+        }
+    }
+
+    fn safe_div(&self, rhs: Self) -> Self {
+        let max = Self::max_value();
+        if rhs == <Self as Number>::zero() {
+            max
+        } else {
+            let res = *self / rhs;
+            if <Self as num_traits::float::Float>::is_finite(res) {
+                res.clamp(-max, max)
+            } else if self.safe_mul(rhs) > <Self as Number>::zero() {
+                // overflow
+                max
+            } else {
+                // underflow
+                -max
+            }
+        }
     }
 
     fn sin(&self) -> T {
@@ -86,7 +150,12 @@ where
 #[cfg(all(feature = "fixed", not(feature = "float")))]
 impl<T> Number for T
 where
-    T: fixed::traits::FixedSigned + cordic::CordicNumber,
+    T: fixed::traits::FixedSigned
+        + cordic::CordicNumber
+        + num_traits::SaturatingAdd
+        + num_traits::SaturatingSub
+        + num_traits::SaturatingMul
+        + num_traits::CheckedDiv,
 {
     fn zero() -> T {
         cordic::CordicNumber::zero()
@@ -100,12 +169,54 @@ where
         T::DELTA
     }
 
+    fn max_value() -> T {
+        T::saturating_recip(Self::epsilon())
+    }
+
     fn pi() -> T {
         cordic::CordicNumber::pi()
     }
 
     fn abs(&self) -> T {
         T::abs(*self)
+    }
+
+    fn clamp(&self, min: T, max: T) -> T {
+        if self < &min {
+            min
+        } else if self > &max {
+            max
+        } else {
+            *self
+        }
+    }
+
+    fn safe_add(&self, rhs: Self) -> Self {
+        let max = Self::max_value();
+        self.saturating_add(&rhs).clamp(-max, max)
+    }
+
+    fn safe_sub(&self, rhs: Self) -> Self {
+        let max = Self::max_value();
+        self.saturating_sub(&rhs).clamp(-max, max)
+    }
+
+    fn safe_mul(&self, rhs: Self) -> Self {
+        let max = Self::max_value();
+        self.saturating_mul(&rhs).clamp(-max, max)
+    }
+
+    fn safe_div(&self, rhs: Self) -> Self {
+        let max = Self::max_value();
+        if let Some(retval) = self.checked_div(&rhs) {
+            retval.clamp(-max, max)
+        } else if self.safe_mul(rhs) >= <Self as Number>::zero() {
+            // overflow or divide-by-zero
+            max
+        } else {
+            // underflow
+            -max
+        }
     }
 
     fn sin(&self) -> T {
@@ -118,58 +229,90 @@ where
 }
 
 // We use this impl when both "float" and "fixed". This mostly just exists to
-// defeat the orphan rule. As far as I know there is no such T which implements
-// both FixedSigned and Real... yet.
+// defeat the orphan rule. There is no such T which implements
+// both FixedSigned and Float.
 #[cfg(all(features = "fixed", feature = "float"))]
 impl<T> Number for T
 where
-    T: fixed::traits::FixedSigned + num_traits::real::Real,
+    T: fixed::traits::FixedSigned + num_traits::float::Float,
 {
     fn zero() -> T {
-        T::zero()
+        unimplemented!()
     }
 
     fn one() -> T {
-        T::one()
+        unimplemented!()
     }
 
     fn epsilon() -> T {
-        T::epsilon()
+        unimplemented!()
+    }
+
+    fn max_value() -> T {
+        unimplemented!()
     }
 
     fn pi() -> T {
-        T::pi()
+        unimplemented!()
     }
 
     fn abs(&self) -> T {
-        T::abs(*self)
+        unimplemented!()
+    }
+
+    fn clamp(&self, min: T, max: T) -> T {
+        unimplemented!()
+    }
+
+    fn safe_add(&self, rhs: Self) -> Self {
+        unimplemented!()
+    }
+
+    fn safe_sub(&self, rhs: Self) -> Self {
+        unimplemented!()
+    }
+
+    fn safe_mul(&self, rhs: Self) -> Self {
+        unimplemented!()
+    }
+
+    fn safe_div(&self, rhs: Self) -> Self {
+        unimplemented!()
     }
 
     fn sin(&self) -> T {
-        T::sin(*self)
+        unimplemented!()
     }
 
     fn cos(&self) -> T {
-        T::cos(*self)
+        unimplemented!()
     }
 }
 
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
-pub enum PidControllerError {
-    Numeric(&'static str),
-    InvalidParameter(&'static str),
+pub enum Parameter {
+    ProportionalGain,
+    IntegralTimeConstant,
+    DerivativeTimeConstant,
+    SetPointCoefficient,
+    InitialControllerOutput,
 }
 
-impl Display for PidControllerError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            PidControllerError::Numeric(s) => f.write_fmt(format_args!("numeric error {s}")),
-            PidControllerError::InvalidParameter(s) => {
-                f.write_fmt(format_args!("invalid parameter {s}"))
-            }
-        }
-    }
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub enum PidControllerError<T>
+where
+    T: Number,
+{
+    UnrepresentableNumber,
+    ParameterOutOfBounds {
+        parameter: Parameter,
+        value: T,
+        lower_bound: T,
+        upper_bound: T,
+    },
+    InvalidTimestamp,
 }
 
 fn check_constants<T>(
@@ -178,44 +321,58 @@ fn check_constants<T>(
     derivative_time_constant: T,
     set_point_coefficient: T,
     initial_controller_output: Option<T>,
-) -> Result<(), PidControllerError>
+) -> Result<(), PidControllerError<T>>
 where
     T: Number,
 {
     let zero = T::zero();
     let eps = T::epsilon();
-    let two = T::one() + T::one();
-    let max = T::one() / (two * two * T::epsilon()); // FIXME: more rigor
+    let max = T::max_value();
 
     if proportional_gain < zero || proportional_gain > max {
-        return Err(PidControllerError::InvalidParameter(
-            "proportional_gain must be in [T::zero(), 1 / T::epsilon()]",
-        ));
+        return Err(PidControllerError::ParameterOutOfBounds {
+            parameter: Parameter::ProportionalGain,
+            value: proportional_gain,
+            lower_bound: zero,
+            upper_bound: max,
+        });
     }
 
     if integral_time_constant < eps || integral_time_constant > max {
-        return Err(PidControllerError::InvalidParameter(
-            "integral_time_constant must be in (T::epsilon(), 1 / T::epsilon()]",
-        ));
+        return Err(PidControllerError::ParameterOutOfBounds {
+            parameter: Parameter::IntegralTimeConstant,
+            value: integral_time_constant,
+            lower_bound: eps,
+            upper_bound: max,
+        });
     }
 
     if derivative_time_constant < eps || derivative_time_constant > max {
-        return Err(PidControllerError::InvalidParameter(
-            "derivative_time_constant must be in (T::epsilon(), 1 / T::epsilon()]",
-        ));
+        return Err(PidControllerError::ParameterOutOfBounds {
+            parameter: Parameter::DerivativeTimeConstant,
+            value: derivative_time_constant,
+            lower_bound: eps,
+            upper_bound: max,
+        });
     }
 
     if set_point_coefficient < zero || set_point_coefficient > max {
-        return Err(PidControllerError::InvalidParameter(
-            "set_point_coefficient must be in [T::zero(), 1 / T::epsilon()]",
-        ));
+        return Err(PidControllerError::ParameterOutOfBounds {
+            parameter: Parameter::SetPointCoefficient,
+            value: set_point_coefficient,
+            lower_bound: zero,
+            upper_bound: max,
+        });
     }
 
     if let Some(u0) = initial_controller_output {
         if u0 < -max || u0 > max {
-            return Err(PidControllerError::InvalidParameter(
-                "initial_controller_output must be in [-1 / T::epsilon(), 1 / T::epsilon()]",
-            ));
+            return Err(PidControllerError::ParameterOutOfBounds {
+                parameter: Parameter::InitialControllerOutput,
+                value: u0,
+                lower_bound: -max,
+                upper_bound: max,
+            });
         }
     }
 
@@ -256,29 +413,29 @@ where
     /// # Arguments:
     /// \
     /// - `proportional_gain` -- The output the controller is multiplied by this
-    ///   factor. Must be in `[T::zero(), 1 / T::epsilon()]`.
+    ///   factor. Must be in `[T::zero(), T::max_value()]`.
     /// \
     /// - `integral_time_constant` -- The time required for the integral term to
     ///   "catch up to" the proportional term in the face of an instantaneous
-    ///   jump in controller error. Must be in `(T::epsilon(), 1 / T::epsilon()]`.
+    ///   jump in controller error. Must be in `(T::epsilon(), T::max_value()]`.
     /// \
     /// - `derivative_time_constant` -- The time required for the proportional
     ///   term to "catch up to" the derivative term if the error starts at zero
-    ///   and increases at a fixed rate. Must be in `(T::epsilon(), 1 / T::epsilon()]`.
+    ///   and increases at a fixed rate. Must be in `(T::epsilon(), T::max_value()]`.
     /// \
     /// - `set_point_coefficient` -- This term determines how the controller
     ///   reacts to a change in the setpoint. Must be in
-    ///   `[T::zero(), 1 / T::epsilon()]`.
+    ///   `[T::zero(), T::max_value()]`.
     /// \
     /// - `initial_controller_output` -- The controller will return this value
-    ///   until it is updated. Must be in `[-1 / T::epsilon(), 1 / T::epsilon()]`.
+    ///   until it is updated. Must be in `[-T::max_value(), T::max_value()]`.
     pub fn new(
         proportional_gain: T,
         integral_time_constant: T,
         derivative_time_constant: T,
         set_point_coefficient: T,
         initial_controller_output: T,
-    ) -> Result<Self, PidControllerError> {
+    ) -> Result<Self, PidControllerError<T>> {
         check_constants(
             proportional_gain,
             integral_time_constant,
@@ -328,7 +485,7 @@ where
         integral_time_constant: T,
         derivative_time_constant: T,
         set_point_coefficient: T,
-    ) -> Result<Self, PidControllerError> {
+    ) -> Result<Self, PidControllerError<T>> {
         check_constants(
             proportional_gain,
             integral_time_constant,
@@ -373,7 +530,7 @@ where
         integral_time_constant: T,
         derivative_time_constant: T,
         set_point_coefficient: T,
-    ) -> Result<(), PidControllerError> {
+    ) -> Result<(), PidControllerError<T>> {
         check_constants(
             proportional_gain,
             integral_time_constant,
@@ -428,17 +585,32 @@ where
     }
 
     fn delta_P(&self, r: T, y: T) -> T {
-        self.K * (self.b * r - y - self.b * self.r_1 + self.y_1)
+        // self.K * (self.b * r - y - self.b * self.r_1 + self.y_1)
+        self.K.safe_mul(
+            self.b
+                .safe_mul(r)
+                .safe_sub(y)
+                .safe_sub(self.b.safe_mul(self.r_1))
+                .safe_add(self.y_1),
+        )
     }
 
     fn delta_I(&self, h: T, r: T, y: T) -> T {
-        (self.K * h / self.T_i) * (r - y)
+        // (self.K * h / self.T_i) * (r - y)
+        self.K
+            .safe_mul(h)
+            .safe_div(self.T_i)
+            .safe_mul(r.safe_sub(y))
     }
 
     fn delta_D(&self, h: T, y: T) -> T {
-        let two = T::one() + T::one();
-
-        ((-self.K * self.T_d) / h) * (y - two * self.y_1 + self.y_2)
+        let two = T::one().safe_add(T::one());
+        // ((-self.K * self.T_d) / h) * (y - two * self.y_1 + self.y_2)
+        -self
+            .K
+            .safe_mul(self.T_d)
+            .safe_div(h)
+            .safe_mul(y.safe_sub(two.safe_mul(self.y_1)).safe_add(self.y_2))
     }
 
     fn update_state(&mut self, h: T, r: T, y: T, u_low: T, u_high: T) -> T {
@@ -446,12 +618,13 @@ where
         let delta_I = self.delta_I(h, r, y);
         let delta_D = self.delta_D(h, y);
 
-        let delta_v = delta_P + delta_I + delta_D;
+        // delta_P + delta_I + delta_D
+        let delta_v = delta_P.safe_add(delta_I).safe_add(delta_D);
 
         // simulate saturating the output -- e.g. an actuator may have a
         // prescribed range beyond which it will not travel no matter the signal
         // it's given.
-        self.u = clamp(self.u + delta_v, u_low, u_high);
+        self.u = self.u.safe_add(delta_v).clamp(u_low, u_high);
 
         self.y_2 = self.y_1;
         self.r_1 = r;
@@ -461,44 +634,24 @@ where
     }
 }
 
-fn clamp<T>(input: T, min: T, max: T) -> T
-where
-    T: PartialOrd,
-{
-    if input < min {
-        min
-    } else if input > max {
-        max
-    } else {
-        input
-    }
-}
-
 #[cfg(feature = "std")]
 pub mod std {
-    use crate::PidControllerError;
+    use crate::{Number, PidControllerError};
     use std::time::SystemTimeError;
 
-    impl From<SystemTimeError> for PidControllerError {
-        fn from(e: SystemTimeError) -> Self {
-            let msg = if let Some(msg) = format_args!(
-                "measurement time was before last update time: {:?}",
-                e.duration()
-            )
-            .as_str()
-            {
-                msg
-            } else {
-                "measurement time was before last update time"
-            };
-
-            Self::InvalidParameter(msg)
+    impl<T> From<SystemTimeError> for PidControllerError<T>
+    where
+        T: Number,
+    {
+        fn from(_: SystemTimeError) -> Self {
+            Self::InvalidTimestamp
         }
     }
 
     #[cfg(feature = "fixed")]
     pub mod fixed {
-        use crate::{Number, PidControllerError};
+        use super::*;
+        use ::fixed::traits::{FixedSigned, LosslessTryFrom};
         use std::time::SystemTime;
 
         /// Compute the number of seconds that has elapsed between
@@ -509,29 +662,32 @@ pub mod std {
         pub fn calculate_h<T>(
             measurement_time: SystemTime,
             last_update_time: SystemTime,
-        ) -> Result<T, PidControllerError>
+        ) -> Result<T, PidControllerError<T>>
         where
-            T: Number + fixed::traits::LosslessTryFrom<u64> + fixed::traits::LosslessTryFrom<u32>,
+            T: Number
+                + FixedSigned
+                + LosslessTryFrom<u64>
+                + LosslessTryFrom<u32>
+                + cordic::CordicNumber,
         {
             let duration = measurement_time.duration_since(last_update_time)?;
 
-            Ok(
-                T::lossless_try_from(duration.as_secs()).ok_or(PidControllerError::Numeric(
-                    "duration's seconds part must be representable as T",
-                ))? + (T::lossless_try_from(duration.subsec_nanos()).ok_or(
-                    PidControllerError::Numeric(
-                        "duration's nanoseconds part must be representable as T",
-                    ),
-                )? / T::lossless_try_from(1_000_000_000_u32).ok_or(
-                    PidControllerError::Numeric("1_000_000_000 must be representable as T"),
-                )?),
-            )
+            Ok(T::lossless_try_from(duration.as_secs())
+                .ok_or(PidControllerError::UnrepresentableNumber)?
+                .safe_add(
+                    T::lossless_try_from(duration.subsec_nanos())
+                        .ok_or(PidControllerError::UnrepresentableNumber)?
+                        .safe_div(
+                            T::lossless_try_from(1_000_000_000_u32)
+                                .ok_or(PidControllerError::UnrepresentableNumber)?,
+                        ),
+                ))
         }
     }
 
     #[cfg(feature = "float")]
     pub mod float {
-        use crate::{Number, PidControllerError};
+        use super::*;
         use std::time::SystemTime;
 
         /// Compute the number of seconds that has elapsed between
@@ -542,21 +698,22 @@ pub mod std {
         pub fn calculate_h<T>(
             measurement_time: SystemTime,
             last_update_time: SystemTime,
-        ) -> Result<T, PidControllerError>
+        ) -> Result<T, PidControllerError<T>>
         where
             T: Number + num_traits::cast::FromPrimitive,
         {
             let duration = measurement_time.duration_since(last_update_time)?;
 
-            Ok(
-                T::from_u64(duration.as_secs()).ok_or(PidControllerError::Numeric(
-                    "duration's seconds part must be representable as T",
-                ))? + (T::from_u32(duration.subsec_nanos()).ok_or(PidControllerError::Numeric(
-                    "duration's nanoseconds part must be representable as T",
-                ))? / T::from_u32(1_000_000_000_u32).ok_or(PidControllerError::Numeric(
-                    "1_000_000_000 must be representable as T",
-                ))?),
-            )
+            Ok(T::from_u64(duration.as_secs())
+                .ok_or(PidControllerError::UnrepresentableNumber)?
+                .safe_add(
+                    T::from_u32(duration.subsec_nanos())
+                        .ok_or(PidControllerError::UnrepresentableNumber)?
+                        .safe_div(
+                            T::from_u32(1_000_000_000_u32)
+                                .ok_or(PidControllerError::UnrepresentableNumber)?,
+                        ),
+                ))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ use core::{
 /// \
 /// - `num_traits::real::Real + num_traits::FloatConst` if compiled with feature
 ///   `"float"`
+/// \
 /// - `fixed::traits::FixedSigned + cordic::CordicNumber` if compiled with
 ///   feature `"fixed"`
 /// \
@@ -163,9 +164,9 @@ pub enum PidControllerError {
 impl Display for PidControllerError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            PidControllerError::Numeric(s) => f.write_fmt(format_args!("numeric error {0}", s)),
+            PidControllerError::Numeric(s) => f.write_fmt(format_args!("numeric error {s}")),
             PidControllerError::InvalidParameter(s) => {
-                f.write_fmt(format_args!("invalid parameter {0}", s))
+                f.write_fmt(format_args!("invalid parameter {s}"))
             }
         }
     }
@@ -183,7 +184,8 @@ where
 {
     let zero = T::zero();
     let eps = T::epsilon();
-    let max = T::one() / eps;
+    let two = T::one() + T::one();
+    let max = T::one() / (two * two * T::epsilon()); // FIXME: more rigor
 
     if proportional_gain < zero || proportional_gain > max {
         return Err(PidControllerError::InvalidParameter(
@@ -528,7 +530,7 @@ pub mod std {
     }
 
     #[cfg(feature = "float")]
-    pub mod real {
+    pub mod float {
         use crate::{Number, PidControllerError};
         use std::time::SystemTime;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,11 +417,11 @@ where
     /// \
     /// - `integral_time_constant` -- The time required for the integral term to
     ///   "catch up to" the proportional term in the face of an instantaneous
-    ///   jump in controller error. Must be in `(T::epsilon(), T::max_value()]`.
+    ///   jump in controller error. Must be in `[T::epsilon(), T::max_value()]`.
     /// \
     /// - `derivative_time_constant` -- The time required for the proportional
     ///   term to "catch up to" the derivative term if the error starts at zero
-    ///   and increases at a fixed rate. Must be in `(T::epsilon(), T::max_value()]`.
+    ///   and increases at a fixed rate. Must be in `[T::epsilon(), T::max_value()]`.
     /// \
     /// - `set_point_coefficient` -- This term determines how the controller
     ///   reacts to a change in the setpoint. Must be in
@@ -465,20 +465,19 @@ where
     /// \
     /// # Arguments:
     /// \
-    /// - `proportional_gain` -- The output the controller is multiplied by this
-    ///   factor. Must be in `[T::zero(), 1 / T::epsilon()]`.
+    /// - `proportional_gain` -- The output of the controller is multiplied by
+    ///   this factor. Must be in `[T::zero(), T::max_value()]`.
     /// \
     /// - `integral_time_constant` -- The time required for the integral term to
     ///   "catch up to" the proportional term in the face of an instantaneous
-    ///   jump in controller error. Must be in `(T::epsilon(), 1 / T::epsilon()]`.
+    ///   jump in controller error. Must be in `[T::epsilon(), T::max_value()]`.
     /// \
     /// - `derivative_time_constant` -- The time required for the proportional
     ///   term to "catch up to" the derivative term if the error starts at zero
-    ///   and increases at a fixed rate. Must be in `(T::epsilon(), 1 / T::epsilon()]`.
+    ///   and increases at a fixed rate. Must be in `[T::epsilon(), T::max_value()]`.
     /// \
     /// - `set_point_coefficient` -- This term determines how the controller
-    ///   reacts to a change in the setpoint. Must be in
-    ///   `[T::zero(), 1 / T::epsilon()]`.
+    ///   reacts to a change in the setpoint. Must be in `[T::zero(), T::max_value()]`.
     pub fn update_constants(
         &self,
         proportional_gain: T,
@@ -511,19 +510,18 @@ where
     /// # Arguments:
     /// \
     /// - `proportional_gain` -- The output the controller is multiplied by this
-    ///   factor. Must be in `[T::zero(), 1 / T::epsilon()]`.
+    ///   factor. Must be in `[T::zero(), T::max_value()]`.
     /// \
     /// - `integral_time_constant` -- The time required for the integral term to
     ///   "catch up to" the proportional term in the face of an instantaneous
-    ///   jump in controller error. Must be in `(T::epsilon(), 1 / T::epsilon()]`.
+    ///   jump in controller error. Must be in `(T::epsilon(), T::max_value()]`.
     /// \
     /// - `derivative_time_constant` -- The time required for the proportional
     ///   term to "catch up to" the derivative term if the error starts at zero
-    ///   and increases at a fixed rate. Must be in `(T::epsilon(), 1 / T::epsilon()]`.
+    ///   and increases at a fixed rate. Must be in `(T::epsilon(), T::max_value()]`.
     /// \
     /// - `set_point_coefficient` -- This term determines how the controller
-    ///   reacts to a change in the setpoint. Must be in
-    ///   `[T::zero(), 1 / T::epsilon()]`.
+    ///   reacts to a change in the setpoint. Must be in `[T::zero(), T::max_value()]`.
     pub fn update_constants_mut(
         &mut self,
         proportional_gain: T,

--- a/tests/fixed.rs
+++ b/tests/fixed.rs
@@ -1,0 +1,108 @@
+#![cfg(all(feature = "std", feature = "fixed"))]
+
+use fixed::{
+    traits::{Fixed, ToFixed},
+    types::I32F32,
+};
+
+use proptest::prelude::*;
+
+use guv::std::fixed::calculate_h;
+
+use guv::Number;
+
+mod strategies;
+
+//
+// property-based tests
+//
+
+proptest! {
+    //
+    // calculate_h tests
+    //
+
+    #[cfg(feature = "fixed")]
+    #[test]
+    fn calculate_h_returns_number_of_seconds_elapsed_fixed64(
+        (before, after) in strategies::ordered_system_times()
+    ) {
+        let h_calc = calculate_h::<I32F32>(after, before)
+            .expect("calculate_h should succeed when measurement_time happens after last_update_time");
+        let h: I32F32 = after.duration_since(before)
+            .expect("before should come before after")
+            .as_secs_f64()
+            .to_fixed();
+        let abs_diff = (h - h_calc).abs();
+
+        assert!(
+            abs_diff <= 1000 * I32F32::DELTA,
+            "delta: {:?}, h_calc: {:?}, h: {:?}, abs_diff: {:?}",
+            I32F32::DELTA,
+            h_calc,
+            h,
+            abs_diff
+        )
+    }
+
+    #[cfg(feature = "fixed")]
+    #[test]
+    fn calculate_h_returns_err_when_measurement_time_before_last_update_time_fixed64(
+        (before, after) in strategies::ordered_system_times()
+    ) {
+        calculate_h::<I32F32>(before, after)
+            .expect_err("calculate_h should fail when measurement_time happens before last_update_time");
+    }
+
+    //
+    // PidController tests
+    //
+
+    #[cfg(feature = "fixed")]
+    #[test]
+    fn trivial_update_should_not_fail_fixed64(
+        pid_controller in strategies::default_pid_controllers::<I32F32>()
+    ) {
+        let mut pid_controller = pid_controller
+            .expect("constructor should not error");
+        assert_eq!(
+            pid_controller
+                .update(
+                    I32F32::ZERO,
+                    I32F32::ZERO,
+                    I32F32::checked_from_num(0.001)
+                        .expect("0.001 must be representable as I32F32"),
+                    I32F32::ZERO,
+                    I32F32::ZERO
+                ),
+            I32F32::ZERO
+        );
+
+        assert_eq!(pid_controller.control_output(), 0.0);
+    }
+}
+
+//
+// visual tests
+//
+
+#[cfg(feature = "fixed")]
+fn process<T: Number + Fixed>(u: T, y: T, t: T) -> T {
+    let two = T::one() + T::one();
+
+    T::from_num(-0.105) * y * t + T::from_num(0.105) * u * (t + two) + (two * T::pi() * t).cos()
+}
+
+#[cfg(feature = "fixed")]
+#[test]
+fn test_process() {
+    let result = process::<I32F32>(I32F32::ZERO, I32F32::ZERO, I32F32::ZERO);
+    let abs_diff = (I32F32::ONE - result).abs();
+    assert!(
+        abs_diff <= 2 * I32F32::DELTA,
+        "delta: {:?}, result: {:?}, abs_diff: {:?}",
+        I32F32::DELTA,
+        result,
+        abs_diff
+    );
+}

--- a/tests/fixed.rs
+++ b/tests/fixed.rs
@@ -1,5 +1,7 @@
 #![cfg(all(feature = "std", feature = "fixed"))]
 
+use std::assert_eq;
+
 use fixed::{
     traits::{Fixed, ToFixed},
     types::I32F32,
@@ -65,20 +67,110 @@ proptest! {
     ) {
         let mut pid_controller = pid_controller
             .expect("constructor should not error");
-        assert_eq!(
-            pid_controller
-                .update(
-                    I32F32::ZERO,
-                    I32F32::ZERO,
-                    I32F32::checked_from_num(0.001)
-                        .expect("0.001 must be representable as I32F32"),
-                    I32F32::ZERO,
-                    I32F32::ZERO
-                ),
+        let result = pid_controller.update(
+            I32F32::ZERO,
+            I32F32::ZERO,
+            I32F32::checked_from_num(0.1)
+                .expect("0.1 must be representable as I32F32"),
+            I32F32::ZERO,
             I32F32::ZERO
         );
 
+        assert_eq!(result, I32F32::ZERO);
         assert_eq!(pid_controller.control_output(), 0.0);
+    }
+
+    #[cfg(feature = "fixed")]
+    #[test]
+    fn in_place_constants_update_should_not_fail_fixed64(
+        proportional_gain in strategies::bounded_numbers(
+            <I32F32 as Number>::zero(), <I32F32 as Number>::max_value()
+        ),
+        integral_time_constant in strategies::bounded_numbers(
+            <I32F32 as Number>::epsilon(), <I32F32 as Number>::max_value()
+        ),
+        derivative_time_constant in strategies::bounded_numbers(
+            <I32F32 as Number>::epsilon(), <I32F32 as Number>::max_value()
+        ),
+        set_point_coefficient in strategies::bounded_numbers(
+            <I32F32 as Number>::zero(), <I32F32 as Number>::max_value()
+        ),
+        pid_controller in strategies::default_pid_controllers::<I32F32>(),
+    ) {
+        let mut pid_controller = pid_controller
+            .expect("constructor should not error");
+
+        let zero = <I32F32 as Number>::zero();
+
+        assert_eq!(
+            pid_controller
+                .update(zero, zero, I32F32::from_num(0.001), zero, zero),
+            zero
+        );
+
+        pid_controller
+            .update_constants_mut(
+                proportional_gain,
+                integral_time_constant,
+                derivative_time_constant,
+                set_point_coefficient,
+            )
+            .expect("updating constants should not fail");
+
+        assert_eq!(
+            pid_controller
+                .update(zero, zero, I32F32::from_num(0.001), zero, zero),
+            zero
+        );
+
+        assert_eq!(pid_controller.control_output(), zero);
+    }
+
+    #[cfg(feature = "fixed")]
+    #[test]
+    fn copy_constants_update_should_not_fail_fixed64(
+        proportional_gain in strategies::bounded_numbers(
+            <I32F32 as Number>::zero(), <I32F32 as Number>::max_value()
+        ),
+        integral_time_constant in strategies::bounded_numbers(
+            <I32F32 as Number>::epsilon(), <I32F32 as Number>::max_value()
+        ),
+        derivative_time_constant in strategies::bounded_numbers(
+            <I32F32 as Number>::epsilon(), <I32F32 as Number>::max_value()
+        ),
+        set_point_coefficient in strategies::bounded_numbers(
+            <I32F32 as Number>::zero(), <I32F32 as Number>::max_value()
+        ),
+        pid_controller in strategies::default_pid_controllers::<I32F32>(),
+    ) {
+        let mut pid_controller = pid_controller
+            .expect("constructor should not error");
+
+        let zero = <I32F32 as Number>::zero();
+
+        assert_eq!(
+            pid_controller
+                .update(zero, zero, I32F32::from_num(0.001), zero, zero),
+            zero
+        );
+
+        let mut another_pid_controller = pid_controller
+            .update_constants(
+                proportional_gain,
+                integral_time_constant,
+                derivative_time_constant,
+                set_point_coefficient,
+            )
+            .expect("updating constants should not fail");
+
+        let one = <I32F32 as Number>::one();
+        let eps = <I32F32 as Number>::epsilon();
+        let one_k = I32F32::from_num(1000);
+
+        another_pid_controller
+            .update(one_k, one_k, eps, -one, one);
+
+        assert_eq!(pid_controller.control_output(), zero);
     }
 }
 
@@ -88,9 +180,17 @@ proptest! {
 
 #[cfg(feature = "fixed")]
 fn process<T: Number + Fixed>(u: T, y: T, t: T) -> T {
-    let two = T::one() + T::one();
-
-    T::from_num(-0.105) * y * t + T::from_num(0.105) * u * (t + two) + (two * T::pi() * t).cos()
+    let two = T::one().safe_add(T::one());
+    // -0.105 * y * t + 0.105 * u * (t + 2.0) + (2.0 * T::pi() * t).cos()
+    <T as Fixed>::from_num(-0.105)
+        .safe_mul(y)
+        .safe_mul(t)
+        .safe_add(
+            <T as Fixed>::from_num(0.105)
+                .safe_mul(u)
+                .safe_mul(t.safe_add(two)),
+        )
+        .safe_add(two.safe_mul(T::pi()).safe_mul(t).cos())
 }
 
 #[cfg(feature = "fixed")]

--- a/tests/float.rs
+++ b/tests/float.rs
@@ -1,163 +1,13 @@
-#![cfg(feature = "std")]
-use std::{
-    fmt::Debug,
-    time::{Duration, SystemTime},
-};
-
-#[cfg(feature = "fixed")]
-use fixed::{
-    traits::{LosslessTryFrom, LossyInto},
-    types::I32F32,
-};
+#![cfg(all(feature = "std", feature = "float"))]
 
 use plotters::prelude::*;
 use proptest::prelude::*;
-use proptest_arbitrary_interop::{arb, ArbInterop};
 
-#[cfg(feature = "float")]
-use guv::std::real::calculate_h;
+use guv::std::float::calculate_h;
 
-#[cfg(feature = "fixed")]
-use guv::std::fixed::calculate_h;
+use guv::{Number, PidController};
 
-use guv::{Number, PidController, PidControllerError};
-
-//
-// proptest strategies
-//
-
-/// This strategy generates real numbers of type `T` on the interval
-/// `(T::epsilon(), T::max_value()]`
-fn positive_nonzero_numbers<T>() -> impl Strategy<Value = T>
-where
-    T: Number + ArbInterop,
-{
-    arb::<T>().prop_map(|n| {
-        let eps = T::epsilon();
-        let n_abs = n.abs();
-
-        if n_abs <= eps {
-            n_abs + eps
-        } else {
-            n_abs
-        }
-    })
-}
-
-/// This strategy generates real numbers of type `T` on the interval
-/// `(T::epsilon(), 1 / T::epsilon()]`
-fn epsilon_epsilon_inverse_bounded_numbers<T>() -> impl Strategy<Value = T>
-where
-    T: Number + ArbInterop,
-{
-    positive_nonzero_numbers::<T>().prop_map(|n| {
-        let one = T::one();
-        let two = one + one;
-        let eps = T::epsilon();
-        let max = one / eps;
-
-        if n > max {
-            let val = max * ((n.sin() + one) / two);
-
-            if val > eps {
-                val
-            } else {
-                eps
-            }
-        } else {
-            n
-        }
-    })
-}
-
-/// This strategy generates real numbers of type `T` on the interval
-/// `[T::zero(), 1 / T::epsilon()]`
-fn zero_epsilon_inverse_bounded_numbers<T>() -> impl Strategy<Value = T>
-where
-    T: Number + ArbInterop,
-{
-    arb::<T>().prop_map(|n| {
-        let one = T::one();
-        let two = one + one;
-        let max = one / T::epsilon();
-
-        max * ((n.sin() + one) / two)
-    })
-}
-
-fn negative_epsilon_inverse_epsilon_inverse_bounded_numbers<T>() -> impl Strategy<Value = T>
-where
-    T: Number + ArbInterop,
-{
-    arb::<T>().prop_map(|n| (T::one() / T::epsilon()) * n.cos())
-}
-
-/// This strategy generates `PidController<T>` structs whose configuration
-/// parameters are themselves individually populated by the given argument
-/// strategies.
-fn pid_controllers<T>(
-    proportional_gains: impl Strategy<Value = T>,
-    integral_time_constants: impl Strategy<Value = T>,
-    derivative_time_constants: impl Strategy<Value = T>,
-    set_point_coefficients: impl Strategy<Value = T>,
-    initial_controller_outputs: impl Strategy<Value = T>,
-) -> impl Strategy<Value = Result<PidController<T>, PidControllerError>>
-where
-    T: Number + Debug,
-{
-    (
-        proportional_gains,
-        integral_time_constants,
-        derivative_time_constants,
-        set_point_coefficients,
-        initial_controller_outputs,
-    )
-        .prop_map(
-            |(
-                proportional_gain,
-                integral_time_constant,
-                derivative_time_constant,
-                set_point_coefficient,
-                initial_controller_output,
-            )| {
-                PidController::new(
-                    proportional_gain,
-                    integral_time_constant,
-                    derivative_time_constant,
-                    set_point_coefficient,
-                    initial_controller_output,
-                )
-            },
-        )
-}
-
-/// This strategy generates `PidController<T>` structs whose configuration
-/// parameters cover the entire permissible domain.
-fn default_pid_controllers<T>(
-) -> impl Strategy<Value = Result<PidController<T>, PidControllerError>>
-where
-    T: Number + ArbInterop,
-{
-    pid_controllers(
-        zero_epsilon_inverse_bounded_numbers(),
-        epsilon_epsilon_inverse_bounded_numbers(),
-        epsilon_epsilon_inverse_bounded_numbers(),
-        zero_epsilon_inverse_bounded_numbers(),
-        negative_epsilon_inverse_epsilon_inverse_bounded_numbers(),
-    )
-}
-
-/// This strategy generates ordered pairs of timestamps `(before, after)`
-/// where `before` is guaranteed to be earlier than `after`.
-#[cfg(feature = "std")]
-fn ordered_system_times() -> impl Strategy<Value = (SystemTime, SystemTime)> {
-    (any::<SystemTime>(), any::<i32>(), 0u32..1_000_000_000u32).prop_map(|(time, delta, nanos)| {
-        (
-            time,
-            time + Duration::new(delta.unsigned_abs() as u64, nanos),
-        )
-    })
-}
+mod strategies;
 
 //
 // property-based tests
@@ -171,7 +21,7 @@ proptest! {
     #[cfg(feature = "float")]
     #[test]
     fn calculate_h_returns_number_of_seconds_elapsed_f64(
-        (before, after) in ordered_system_times()
+        (before, after) in strategies::ordered_system_times()
     ) {
         assert_eq!(
             calculate_h::<f64>(after, before)
@@ -183,7 +33,7 @@ proptest! {
     #[cfg(feature = "float")]
     #[test]
     fn calculate_h_returns_number_of_seconds_elapsed_f32(
-        (before, after) in ordered_system_times()
+        (before, after) in strategies::ordered_system_times()
     ) {
         assert_eq!(
             calculate_h::<f32>(after, before)
@@ -192,32 +42,10 @@ proptest! {
         )
     }
 
-    #[cfg(feature = "fixed")]
-    #[test]
-    fn calculate_h_returns_number_of_seconds_elapsed_fixed64(
-        (before, after) in ordered_system_times()
-    ) {
-        let delta = LossyInto::<f64>::lossy_into(I32F32::DELTA);
-        let h_calc = LossyInto::<f64>::lossy_into(
-            calculate_h::<I32F32>(after, before)
-                .expect("calculate_h should succeed when measurement_time happens after last_update_time")
-        );
-        let h = after.duration_since(before)
-            .expect("before should come before after")
-            .as_secs_f64();
-        let abs_diff = (h - h_calc).abs();
-
-        assert!(
-            abs_diff <= 2.0 * delta,
-            "delta: {:?}, h_calc: {:?}, h: {:?}, abs_diff: {:?}",
-            delta, h_calc, h, abs_diff
-        )
-    }
-
     #[cfg(feature = "float")]
     #[test]
     fn calculate_h_returns_err_when_measurement_time_before_last_update_time_f64(
-        (before, after) in ordered_system_times()
+        (before, after) in strategies::ordered_system_times()
     ) {
         calculate_h::<f64>(before, after)
             .expect_err("calculate_h should fail when measurement_time happens before last_update_time");
@@ -226,18 +54,9 @@ proptest! {
     #[cfg(feature = "float")]
     #[test]
     fn calculate_h_returns_err_when_measurement_time_before_last_update_time_f32(
-        (before, after) in ordered_system_times()
+        (before, after) in strategies::ordered_system_times()
     ) {
         calculate_h::<f32>(before, after)
-            .expect_err("calculate_h should fail when measurement_time happens before last_update_time");
-    }
-
-    #[cfg(feature = "fixed")]
-    #[test]
-    fn calculate_h_returns_err_when_measurement_time_before_last_update_time_fixed64(
-        (before, after) in ordered_system_times()
-    ) {
-        calculate_h::<I32F32>(before, after)
             .expect_err("calculate_h should fail when measurement_time happens before last_update_time");
     }
 
@@ -248,7 +67,7 @@ proptest! {
     #[cfg(feature = "float")]
     #[test]
     fn trivial_update_should_not_fail_f64(
-        pid_controller in default_pid_controllers::<f64>()
+        pid_controller in strategies::default_pid_controllers::<f64>()
     ) {
         let mut pid_controller = pid_controller
             .expect("constructor should not error");
@@ -265,7 +84,7 @@ proptest! {
     #[cfg(feature = "float")]
     #[test]
     fn trivial_update_should_not_fail_f32(
-        pid_controller in default_pid_controllers::<f32>()
+        pid_controller in strategies::default_pid_controllers::<f32>()
     ) {
         let mut pid_controller = pid_controller
             .expect("constructor should not error");
@@ -278,37 +97,14 @@ proptest! {
         assert_eq!(pid_controller.control_output(), 0.0);
     }
 
-    #[cfg(feature = "fixed")]
-    #[test]
-    fn trivial_update_should_not_fail_fixed64(
-        pid_controller in default_pid_controllers::<I32F32>()
-    ) {
-        let mut pid_controller = pid_controller
-            .expect("constructor should not error");
-        assert_eq!(
-            pid_controller
-                .update(
-                    I32F32::ZERO,
-                    I32F32::ZERO,
-                    I32F32::checked_from_num(0.001)
-                        .expect("0.001 must be representable as I32F32"),
-                    I32F32::ZERO,
-                    I32F32::ZERO
-                ),
-            I32F32::ZERO
-        );
-
-        assert_eq!(pid_controller.control_output(), 0.0);
-    }
-
     #[cfg(feature = "float")]
     #[test]
     fn in_place_constants_update_should_not_fail_f64(
-        proportional_gain in zero_epsilon_inverse_bounded_numbers(),
-        integral_time_constant in epsilon_epsilon_inverse_bounded_numbers(),
-        derivative_time_constant in epsilon_epsilon_inverse_bounded_numbers(),
-        set_point_coefficient in zero_epsilon_inverse_bounded_numbers(),
-        pid_controller in default_pid_controllers::<f64>(),
+        proportional_gain in strategies::zero_epsilon_inverse_bounded_numbers(),
+        integral_time_constant in strategies::epsilon_epsilon_inverse_bounded_numbers(),
+        derivative_time_constant in strategies::epsilon_epsilon_inverse_bounded_numbers(),
+        set_point_coefficient in strategies::zero_epsilon_inverse_bounded_numbers(),
+        pid_controller in strategies::default_pid_controllers::<f64>(),
     ) {
         let mut pid_controller = pid_controller
             .expect("constructor should not error");
@@ -340,11 +136,11 @@ proptest! {
     #[cfg(feature = "float")]
     #[test]
     fn in_place_constants_update_should_not_fail_f32(
-        proportional_gain in zero_epsilon_inverse_bounded_numbers(),
-        integral_time_constant in epsilon_epsilon_inverse_bounded_numbers(),
-        derivative_time_constant in epsilon_epsilon_inverse_bounded_numbers(),
-        set_point_coefficient in zero_epsilon_inverse_bounded_numbers(),
-        pid_controller in default_pid_controllers::<f32>(),
+        proportional_gain in strategies::zero_epsilon_inverse_bounded_numbers(),
+        integral_time_constant in strategies::epsilon_epsilon_inverse_bounded_numbers(),
+        derivative_time_constant in strategies::epsilon_epsilon_inverse_bounded_numbers(),
+        set_point_coefficient in strategies::zero_epsilon_inverse_bounded_numbers(),
+        pid_controller in strategies::default_pid_controllers::<f32>(),
     ) {
         let mut pid_controller = pid_controller
             .expect("constructor should not error");
@@ -376,11 +172,11 @@ proptest! {
     #[cfg(feature = "float")]
     #[test]
     fn copy_constants_update_should_not_fail_f64(
-        proportional_gain in zero_epsilon_inverse_bounded_numbers(),
-        integral_time_constant in epsilon_epsilon_inverse_bounded_numbers(),
-        derivative_time_constant in epsilon_epsilon_inverse_bounded_numbers(),
-        set_point_coefficient in zero_epsilon_inverse_bounded_numbers(),
-        pid_controller in default_pid_controllers::<f64>(),
+        proportional_gain in strategies::zero_epsilon_inverse_bounded_numbers(),
+        integral_time_constant in strategies::epsilon_epsilon_inverse_bounded_numbers(),
+        derivative_time_constant in strategies::epsilon_epsilon_inverse_bounded_numbers(),
+        set_point_coefficient in strategies::zero_epsilon_inverse_bounded_numbers(),
+        pid_controller in strategies::default_pid_controllers::<f64>(),
     ) {
         let mut pid_controller = pid_controller
             .expect("constructor should not error");
@@ -414,11 +210,11 @@ proptest! {
     #[cfg(feature = "float")]
     #[test]
     fn copy_constants_update_should_not_fail_f32(
-        proportional_gain in zero_epsilon_inverse_bounded_numbers(),
-        integral_time_constant in epsilon_epsilon_inverse_bounded_numbers(),
-        derivative_time_constant in epsilon_epsilon_inverse_bounded_numbers(),
-        set_point_coefficient in zero_epsilon_inverse_bounded_numbers(),
-        pid_controller in default_pid_controllers::<f32>(),
+        proportional_gain in strategies::zero_epsilon_inverse_bounded_numbers(),
+        integral_time_constant in strategies::epsilon_epsilon_inverse_bounded_numbers(),
+        derivative_time_constant in strategies::epsilon_epsilon_inverse_bounded_numbers(),
+        set_point_coefficient in strategies::zero_epsilon_inverse_bounded_numbers(),
+        pid_controller in strategies::default_pid_controllers::<f32>(),
     ) {
         let mut pid_controller = pid_controller
             .expect("constructor should not error");
@@ -460,15 +256,6 @@ fn process<T: Number + num_traits::cast::FromPrimitive>(u: T, y: T, t: T) -> T {
 
     T::from_f32(-0.105).unwrap() * y * t
         + T::from_f32(0.105).unwrap() * u * (t + two)
-        + (two * T::pi() * t).cos()
-}
-
-#[cfg(feature = "fixed")]
-fn process<T: Number + LosslessTryFrom<f32>>(u: T, y: T, t: T) -> T {
-    let two = T::one() + T::one();
-
-    T::lossless_try_from(-0.105).unwrap() * y * t
-        + T::lossless_try_from(0.105).unwrap() * u * (t + two)
         + (two * T::pi() * t).cos()
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -20,11 +20,7 @@ use guv::std::real::calculate_h;
 #[cfg(feature = "fixed")]
 use guv::std::fixed::calculate_h;
 
-use guv::{
-    Number,
-    PidController,
-    PidControllerError
-};
+use guv::{Number, PidController, PidControllerError};
 
 //
 // proptest strategies
@@ -91,11 +87,9 @@ where
 
 fn negative_epsilon_inverse_epsilon_inverse_bounded_numbers<T>() -> impl Strategy<Value = T>
 where
-    T: Number + ArbInterop
+    T: Number + ArbInterop,
 {
-    arb::<T>().prop_map(|n| {
-        (T::one() / T::epsilon()) * n.cos()
-    })
+    arb::<T>().prop_map(|n| (T::one() / T::epsilon()) * n.cos())
 }
 
 /// This strategy generates `PidController<T>` structs whose configuration

--- a/tests/strategies/mod.rs
+++ b/tests/strategies/mod.rs
@@ -1,0 +1,351 @@
+#![cfg(feature = "std")]
+
+use std::{
+    fmt::Debug,
+    time::{Duration, SystemTime},
+};
+
+#[cfg(all(feature = "float", not(feature = "fixed")))]
+use num_traits::float::Float;
+
+#[cfg(all(feature = "fixed", not(feature = "float")))]
+use fixed::traits::Fixed;
+
+use proptest::prelude::*;
+use proptest_arbitrary_interop::{arb, ArbInterop};
+
+use guv::{Number, PidController, PidControllerError};
+
+//
+// proptest strategies
+//
+
+#[cfg(all(feature = "float", not(feature = "fixed")))]
+fn make_behave<T>(n: T) -> T
+where
+    T: Number + ArbInterop + Float + Debug,
+{
+    if Float::is_nan(n) {
+        <T as Number>::zero()
+    } else if Float::is_infinite(n) {
+        if <T as Float>::is_sign_positive(n) {
+            <T as Float>::max_value()
+        } else {
+            <T as Float>::min_value()
+        }
+    } else {
+        n
+    }
+}
+
+#[cfg(all(feature = "float", not(feature = "fixed")))]
+pub fn well_behaved_numbers<T>() -> impl Strategy<Value = T>
+where
+    T: Number + ArbInterop + Float + Debug,
+{
+    arb::<T>().prop_map(make_behave)
+}
+
+#[cfg(all(feature = "fixed", not(feature = "float")))]
+pub fn well_behaved_numbers<T>() -> impl Strategy<Value = T>
+where
+    T: Number + ArbInterop + Fixed + Debug,
+{
+    arb::<T>()
+}
+
+/// This strategy generates real numbers of type `T` on the interval
+/// `(T::epsilon(), T::max_value()]`
+#[cfg(all(feature = "float", not(feature = "fixed")))]
+pub fn positive_nonzero_numbers<T>() -> impl Strategy<Value = T>
+where
+    T: Number + ArbInterop + Float + Debug,
+{
+    well_behaved_numbers()
+        .prop_map(|n: T| {
+            let eps = <T as Number>::epsilon();
+            let n_abs = n.abs();
+
+            if n_abs <= eps {
+                n_abs + eps
+            } else {
+                n_abs
+            }
+        })
+        .prop_map(make_behave)
+}
+
+/// This strategy generates real numbers of type `T` on the interval
+/// `(T::epsilon(), T::max_value()]`
+#[cfg(all(feature = "fixed", not(feature = "float")))]
+pub fn positive_nonzero_numbers<T>() -> impl Strategy<Value = T>
+where
+    T: Number + ArbInterop + Fixed + Debug,
+{
+    well_behaved_numbers().prop_map(|n: T| {
+        let eps = <T as Number>::epsilon();
+        let n_abs = n.abs();
+
+        if n_abs <= eps {
+            n_abs + eps
+        } else {
+            n_abs
+        }
+    })
+}
+
+/// This strategy generates real numbers of type `T` on the interval
+/// `(T::epsilon(), 1 / T::epsilon()]`
+#[cfg(all(feature = "float", not(feature = "fixed")))]
+pub fn epsilon_epsilon_inverse_bounded_numbers<T>() -> impl Strategy<Value = T>
+where
+    T: Number + ArbInterop + Float + Debug,
+{
+    positive_nonzero_numbers::<T>()
+        .prop_map(|n: T| {
+            let one = <T as Number>::one();
+            let two = one + one;
+            let eps = <T as Number>::epsilon();
+            let max = one / (two * two * eps); // FIXME: more rigor
+
+            if n > max {
+                let val = max * ((n.sin() + one) / two);
+
+                if val > eps {
+                    val
+                } else {
+                    eps
+                }
+            } else {
+                n
+            }
+        })
+        .prop_map(make_behave)
+}
+
+/// This strategy generates real numbers of type `T` on the interval
+/// `(T::epsilon(), 1 / T::epsilon()]`
+#[cfg(all(feature = "fixed", not(feature = "float")))]
+pub fn epsilon_epsilon_inverse_bounded_numbers<T>() -> impl Strategy<Value = T>
+where
+    T: Number + ArbInterop + Fixed + Debug,
+{
+    positive_nonzero_numbers::<T>().prop_map(|n: T| {
+        let one = <T as Number>::one();
+        let two = one + one;
+        let eps = <T as Number>::epsilon();
+        let max = (two * two * T::epsilon()).recip(); // FIXME: more rigor
+
+        if n > max {
+            let val = max * ((n.sin() + one) / two);
+
+            if val > eps {
+                val
+            } else {
+                eps
+            }
+        } else {
+            n
+        }
+    })
+}
+
+/// This strategy generates real numbers of type `T` on the interval
+/// `[T::zero(), 1 / T::epsilon()]`
+#[cfg(all(feature = "float", not(feature = "fixed")))]
+pub fn zero_epsilon_inverse_bounded_numbers<T>() -> impl Strategy<Value = T>
+where
+    T: Number + ArbInterop + Float + Debug,
+{
+    well_behaved_numbers()
+        .prop_map(|n: T| {
+            let one = <T as Number>::one();
+            let two = one + one;
+            let max = one / (two * two * <T as Number>::epsilon()); // FIXME: more rigor
+
+            max * ((n.sin() + one) / two)
+        })
+        .prop_map(make_behave)
+}
+
+/// This strategy generates real numbers of type `T` on the interval
+/// `[T::zero(), 1 / T::epsilon()]`
+#[cfg(all(feature = "fixed", not(feature = "float")))]
+pub fn zero_epsilon_inverse_bounded_numbers<T>() -> impl Strategy<Value = T>
+where
+    T: Number + ArbInterop + Fixed + Debug,
+{
+    well_behaved_numbers().prop_map(|n: T| {
+        let one = <T as Number>::one();
+        let two = one + one;
+        let max = (two * two * T::epsilon()).recip(); // FIXME: more rigor
+
+        max * ((n.sin() + one) / two)
+    })
+}
+
+#[cfg(all(feature = "float", not(feature = "fixed")))]
+pub fn negative_epsilon_inverse_epsilon_inverse_bounded_numbers<T>() -> impl Strategy<Value = T>
+where
+    T: Number + ArbInterop + Float + Debug,
+{
+    arb::<T>()
+        .prop_map(|n| {
+            let one = <T as Number>::one();
+            let two = one + one;
+            let max = one / (two * two * <T as Number>::epsilon()); // FIXME: more rigor
+            max * n.cos()
+        })
+        .prop_map(make_behave)
+}
+
+#[cfg(all(feature = "fixed", not(feature = "float")))]
+pub fn negative_epsilon_inverse_epsilon_inverse_bounded_numbers<T>() -> impl Strategy<Value = T>
+where
+    T: Number + ArbInterop + Fixed + Debug,
+{
+    arb::<T>().prop_map(|n| {
+        let one = <T as Number>::one();
+        let two = one + one;
+        let max = (two * two * T::epsilon()).recip(); // FIXME: more rigor
+        max * n.cos()
+    })
+}
+
+/// This strategy generates `PidController<T>` structs whose configuration
+/// parameters are themselves individually populated by the given argument
+/// strategies.
+#[cfg(all(feature = "float", not(feature = "fixed")))]
+pub fn pid_controllers<T>(
+    proportional_gains: impl Strategy<Value = T>,
+    integral_time_constants: impl Strategy<Value = T>,
+    derivative_time_constants: impl Strategy<Value = T>,
+    set_point_coefficients: impl Strategy<Value = T>,
+    initial_controller_outputs: impl Strategy<Value = T>,
+) -> impl Strategy<Value = Result<PidController<T>, PidControllerError>>
+where
+    T: Number + ArbInterop + Float + Debug,
+{
+    (
+        proportional_gains,
+        integral_time_constants,
+        derivative_time_constants,
+        set_point_coefficients,
+        initial_controller_outputs,
+    )
+        .prop_map(
+            |(
+                proportional_gain,
+                integral_time_constant,
+                derivative_time_constant,
+                set_point_coefficient,
+                initial_controller_output,
+            )| {
+                PidController::new(
+                    proportional_gain,
+                    integral_time_constant,
+                    derivative_time_constant,
+                    set_point_coefficient,
+                    initial_controller_output,
+                )
+            },
+        )
+}
+
+/// This strategy generates `PidController<T>` structs whose configuration
+/// parameters are themselves individually populated by the given argument
+/// strategies.
+#[cfg(all(feature = "fixed", not(feature = "float")))]
+pub fn pid_controllers<T>(
+    proportional_gains: impl Strategy<Value = T>,
+    integral_time_constants: impl Strategy<Value = T>,
+    derivative_time_constants: impl Strategy<Value = T>,
+    set_point_coefficients: impl Strategy<Value = T>,
+    initial_controller_outputs: impl Strategy<Value = T>,
+) -> impl Strategy<Value = Result<PidController<T>, PidControllerError>>
+where
+    T: Number + ArbInterop + Fixed + Debug,
+{
+    (
+        proportional_gains,
+        integral_time_constants,
+        derivative_time_constants,
+        set_point_coefficients,
+        initial_controller_outputs,
+    )
+        .prop_map(
+            |(
+                proportional_gain,
+                integral_time_constant,
+                derivative_time_constant,
+                set_point_coefficient,
+                initial_controller_output,
+            )| {
+                PidController::new(
+                    proportional_gain,
+                    integral_time_constant,
+                    derivative_time_constant,
+                    set_point_coefficient,
+                    initial_controller_output,
+                )
+            },
+        )
+}
+
+/// This strategy generates `PidController<T>` structs whose configuration
+/// parameters cover the entire permissible domain.
+#[cfg(all(feature = "float", not(feature = "fixed")))]
+pub fn default_pid_controllers<T>(
+) -> impl Strategy<Value = Result<PidController<T>, PidControllerError>>
+where
+    T: Number + ArbInterop + Float + Debug,
+{
+    pid_controllers(
+        zero_epsilon_inverse_bounded_numbers(),
+        epsilon_epsilon_inverse_bounded_numbers(),
+        epsilon_epsilon_inverse_bounded_numbers(),
+        zero_epsilon_inverse_bounded_numbers(),
+        negative_epsilon_inverse_epsilon_inverse_bounded_numbers(),
+    )
+}
+
+/// This strategy generates `PidController<T>` structs whose configuration
+/// parameters cover the entire permissible domain.
+#[cfg(all(feature = "fixed", not(feature = "float")))]
+pub fn default_pid_controllers<T>(
+) -> impl Strategy<Value = Result<PidController<T>, PidControllerError>>
+where
+    T: Number + ArbInterop + Fixed + Debug,
+{
+    pid_controllers(
+        zero_epsilon_inverse_bounded_numbers(),
+        epsilon_epsilon_inverse_bounded_numbers(),
+        epsilon_epsilon_inverse_bounded_numbers(),
+        zero_epsilon_inverse_bounded_numbers(),
+        negative_epsilon_inverse_epsilon_inverse_bounded_numbers(),
+    )
+}
+
+/// This strategy generates ordered pairs of timestamps `(before, after)`
+/// where `before` is guaranteed to be earlier than `after`.
+#[cfg(all(feature = "float", not(feature = "fixed")))]
+pub fn ordered_system_times() -> impl Strategy<Value = (SystemTime, SystemTime)> {
+    (any::<SystemTime>(), any::<i32>(), 0u32..1_000_000_000u32).prop_map(|(time, delta, nanos)| {
+        (
+            time,
+            time + Duration::new(delta.unsigned_abs() as u64, nanos),
+        )
+    })
+}
+
+/// This strategy generates ordered pairs of timestamps `(before, after)`
+/// where `before` is guaranteed to be earlier than `after`.
+#[cfg(all(feature = "fixed", not(feature = "float")))]
+pub fn ordered_system_times() -> impl Strategy<Value = (SystemTime, SystemTime)> {
+    (any::<SystemTime>(), any::<i32>(), 0u32..1_000_000_000u32).prop_map(|(time, delta, nanos)| {
+        (
+            time,
+            time + Duration::new(delta.unsigned_abs() as u64, nanos),
+        )
+    })
+}

--- a/tests/strategies/mod.rs
+++ b/tests/strategies/mod.rs
@@ -43,7 +43,7 @@ where
 }
 
 /// This strategy generates arbitrary floating point numbers on the interval
-/// `[T::min_value(), T::max_value()]` and ensures no `NaN` or `Inf` values are
+/// `[-T::max_value(), T::max_value()]` and ensures no `NaN` or `Inf` values are
 /// present.
 #[cfg(all(feature = "float", not(feature = "fixed")))]
 pub fn well_behaved_numbers<T>() -> impl Strategy<Value = T>
@@ -53,7 +53,8 @@ where
     arb::<T>().prop_map(make_behave)
 }
 
-/// This strategy generates arbitrary fixed point numbers.
+/// This strategy generates arbitrary fixed point numbers on the interval
+/// `[-T::max_value(), T::max_value()]`.
 #[cfg(all(feature = "fixed", not(feature = "float")))]
 pub fn well_behaved_numbers<T>() -> impl Strategy<Value = T>
 where
@@ -63,7 +64,7 @@ where
     arb::<T>().prop_map(move |n| n.clamp(-max, max))
 }
 
-/// Constrain the input `n` to the interval `(low, high]`
+/// Constrain the input `n` to the interval `[low, high]`
 #[cfg(all(feature = "float", not(feature = "fixed")))]
 fn bound<T>(low: T, high: T, n: T) -> T
 where
@@ -79,7 +80,7 @@ where
     )
 }
 
-/// Constrain the input `n` to the interval `(low, high]`
+/// Constrain the input `n` to the interval `[low, high]`
 #[cfg(all(feature = "fixed", not(feature = "float")))]
 fn bound<T>(low: T, high: T, n: T) -> T
 where
@@ -96,7 +97,7 @@ where
 }
 
 /// This strategy generates real numbers of type `T` on the interval
-/// `(low, high]`
+/// `[low, high]`
 #[cfg(all(feature = "float", not(feature = "fixed")))]
 pub fn bounded_numbers<T>(low: T, high: T) -> impl Strategy<Value = T>
 where
@@ -106,7 +107,7 @@ where
 }
 
 /// This strategy generates real numbers of type `T` on the interval
-/// `(low, high]`
+/// `[low, high]`
 #[cfg(all(feature = "fixed", not(feature = "float")))]
 pub fn bounded_numbers<T>(low: T, high: T) -> impl Strategy<Value = T>
 where
@@ -138,7 +139,7 @@ where
 }
 
 /// This strategy generates tuples of numbers `(low, high)` where high > low and
-/// low + high < T::MAX.
+/// low + high < T::max_value().
 #[cfg(all(feature = "fixed", not(feature = "float")))]
 fn ordered_pairs<T>() -> impl Strategy<Value = (T, T)>
 where

--- a/tests/strategies/mod.rs
+++ b/tests/strategies/mod.rs
@@ -9,7 +9,7 @@ use std::{
 use num_traits::float::Float;
 
 #[cfg(all(feature = "fixed", not(feature = "float")))]
-use fixed::traits::Fixed;
+use fixed::{traits::Fixed, types::I32F32};
 
 use proptest::prelude::*;
 use proptest_arbitrary_interop::{arb, ArbInterop};
@@ -20,24 +20,31 @@ use guv::{Number, PidController, PidControllerError};
 // proptest strategies
 //
 
+/// Constrain the input `n` to the interval `[-T::max_value(), T::max_value()]`
+/// and map `NaN` values to zero. This makes sure `NaN` and `Inf` are never
+/// returned.
 #[cfg(all(feature = "float", not(feature = "fixed")))]
 fn make_behave<T>(n: T) -> T
 where
     T: Number + ArbInterop + Float + Debug,
 {
+    let max = <T as Number>::max_value();
     if Float::is_nan(n) {
         <T as Number>::zero()
     } else if Float::is_infinite(n) {
         if <T as Float>::is_sign_positive(n) {
-            <T as Float>::max_value()
+            max
         } else {
-            <T as Float>::min_value()
+            -max
         }
     } else {
-        n
+        n.clamp(-max, max)
     }
 }
 
+/// This strategy generates arbitrary floating point numbers on the interval
+/// `[T::min_value(), T::max_value()]` and ensures no `NaN` or `Inf` values are
+/// present.
 #[cfg(all(feature = "float", not(feature = "fixed")))]
 pub fn well_behaved_numbers<T>() -> impl Strategy<Value = T>
 where
@@ -46,306 +53,396 @@ where
     arb::<T>().prop_map(make_behave)
 }
 
+/// This strategy generates arbitrary fixed point numbers.
 #[cfg(all(feature = "fixed", not(feature = "float")))]
 pub fn well_behaved_numbers<T>() -> impl Strategy<Value = T>
 where
     T: Number + ArbInterop + Fixed + Debug,
 {
-    arb::<T>()
+    let max = <T as Number>::max_value();
+    arb::<T>().prop_map(move |n| n.clamp(-max, max))
 }
 
-/// This strategy generates real numbers of type `T` on the interval
-/// `(T::epsilon(), T::max_value()]`
+/// Constrain the input `n` to the interval `(low, high]`
 #[cfg(all(feature = "float", not(feature = "fixed")))]
-pub fn positive_nonzero_numbers<T>() -> impl Strategy<Value = T>
+fn bound<T>(low: T, high: T, n: T) -> T
 where
     T: Number + ArbInterop + Float + Debug,
 {
-    well_behaved_numbers()
-        .prop_map(|n: T| {
-            let eps = <T as Number>::epsilon();
-            let n_abs = n.abs();
-
-            if n_abs <= eps {
-                n_abs + eps
-            } else {
-                n_abs
-            }
-        })
-        .prop_map(make_behave)
+    let two = <T as Number>::one() + <T as Number>::one();
+    let max = <T as Number>::max_value();
+    // low + ((high - low) / (2.0 * max)) * (n + max)
+    low.safe_add(
+        high.safe_sub(low)
+            .safe_div(two.safe_mul(max))
+            .safe_mul(n.safe_add(max)),
+    )
 }
 
-/// This strategy generates real numbers of type `T` on the interval
-/// `(T::epsilon(), T::max_value()]`
+/// Constrain the input `n` to the interval `(low, high]`
 #[cfg(all(feature = "fixed", not(feature = "float")))]
-pub fn positive_nonzero_numbers<T>() -> impl Strategy<Value = T>
+fn bound<T>(low: T, high: T, n: T) -> T
 where
     T: Number + ArbInterop + Fixed + Debug,
 {
-    well_behaved_numbers().prop_map(|n: T| {
-        let eps = <T as Number>::epsilon();
-        let n_abs = n.abs();
+    let two = <T as Number>::one() + <T as Number>::one();
+    let max = <T as Number>::max_value();
+    // low + ((high - low) / (2.0 * max)) * (n + max)
+    low.safe_add(
+        high.safe_sub(low)
+            .safe_div(two.safe_mul(max))
+            .safe_mul(n.safe_add(max)),
+    )
+}
 
-        if n_abs <= eps {
-            n_abs + eps
+/// This strategy generates real numbers of type `T` on the interval
+/// `(low, high]`
+#[cfg(all(feature = "float", not(feature = "fixed")))]
+pub fn bounded_numbers<T>(low: T, high: T) -> impl Strategy<Value = T>
+where
+    T: Number + ArbInterop + Float + Debug,
+{
+    well_behaved_numbers().prop_map(move |n: T| bound(low, high, n))
+}
+
+/// This strategy generates real numbers of type `T` on the interval
+/// `(low, high]`
+#[cfg(all(feature = "fixed", not(feature = "float")))]
+pub fn bounded_numbers<T>(low: T, high: T) -> impl Strategy<Value = T>
+where
+    T: Number + ArbInterop + Fixed + Debug,
+{
+    well_behaved_numbers().prop_map(move |n: T| bound(low, high, n))
+}
+
+/// This strategy generates tuples of numbers `(low, high)` where high > low and
+/// low + high < T::max_value().
+#[cfg(all(feature = "float", not(feature = "fixed")))]
+fn ordered_pairs<T>() -> impl Strategy<Value = (T, T)>
+where
+    T: Number + ArbInterop + Float + Debug,
+{
+    (well_behaved_numbers::<T>(), well_behaved_numbers::<T>()).prop_map(|(m, n)| {
+        let max = <T as Number>::max_value();
+        let one = <T as Number>::one();
+        let low = bound(-max, max, m);
+        let high = bound(-max, max, n);
+        if high > low {
+            (low, high)
+        } else if high == low {
+            (low.safe_sub(one), high.safe_add(one))
         } else {
-            n_abs
+            (high, low)
         }
     })
 }
 
-/// This strategy generates real numbers of type `T` on the interval
-/// `(T::epsilon(), 1 / T::epsilon()]`
+/// This strategy generates tuples of numbers `(low, high)` where high > low and
+/// low + high < T::MAX.
+#[cfg(all(feature = "fixed", not(feature = "float")))]
+fn ordered_pairs<T>() -> impl Strategy<Value = (T, T)>
+where
+    T: Number + ArbInterop + Fixed + Debug,
+{
+    (well_behaved_numbers::<T>(), well_behaved_numbers::<T>()).prop_map(|(m, n)| {
+        let max = <T as Number>::max_value();
+        let one = <T as Number>::one();
+        let low = bound(-max, max, m);
+        let high = bound(-max, max, n);
+        if high > low {
+            (low, high)
+        } else if high == low {
+            (low.safe_sub(one), high.safe_add(one))
+        } else {
+            (high, low)
+        }
+    })
+}
+
 #[cfg(all(feature = "float", not(feature = "fixed")))]
-pub fn epsilon_epsilon_inverse_bounded_numbers<T>() -> impl Strategy<Value = T>
+fn arbitrary_bounded_numbers<T>() -> impl Strategy<Value = (T, T, T)>
 where
     T: Number + ArbInterop + Float + Debug,
 {
-    positive_nonzero_numbers::<T>()
-        .prop_map(|n: T| {
-            let one = <T as Number>::one();
-            let two = one + one;
-            let eps = <T as Number>::epsilon();
-            let max = one / (two * two * eps); // FIXME: more rigor
+    ordered_pairs().prop_flat_map(|(low, high)| (Just(low), Just(high), bounded_numbers(low, high)))
+}
 
-            if n > max {
-                let val = max * ((n.sin() + one) / two);
+#[cfg(all(feature = "fixed", not(feature = "float")))]
+fn arbitrary_bounded_numbers<T>() -> impl Strategy<Value = (T, T, T)>
+where
+    T: Number + ArbInterop + Fixed + Debug,
+{
+    ordered_pairs().prop_flat_map(|(low, high)| (Just(low), Just(high), bounded_numbers(low, high)))
+}
 
-                if val > eps {
-                    val
-                } else {
-                    eps
-                }
-            } else {
+/// This strategy generates `PidController<T>` structs whose configuration
+/// parameters are themselves individually populated by the given argument
+/// strategies.
+#[cfg(all(feature = "float", not(feature = "fixed")))]
+pub fn pid_controllers<T>(
+    proportional_gains: impl Strategy<Value = T>,
+    integral_time_constants: impl Strategy<Value = T>,
+    derivative_time_constants: impl Strategy<Value = T>,
+    set_point_coefficients: impl Strategy<Value = T>,
+    initial_controller_outputs: impl Strategy<Value = T>,
+) -> impl Strategy<Value = Result<PidController<T>, PidControllerError<T>>>
+where
+    T: Number + ArbInterop + Float + Debug,
+{
+    (
+        proportional_gains,
+        integral_time_constants,
+        derivative_time_constants,
+        set_point_coefficients,
+        initial_controller_outputs,
+    )
+        .prop_map(
+            |(
+                proportional_gain,
+                integral_time_constant,
+                derivative_time_constant,
+                set_point_coefficient,
+                initial_controller_output,
+            )| {
+                PidController::new(
+                    proportional_gain,
+                    integral_time_constant,
+                    derivative_time_constant,
+                    set_point_coefficient,
+                    initial_controller_output,
+                )
+            },
+        )
+}
+
+/// This strategy generates `PidController<T>` structs whose configuration
+/// parameters are themselves individually populated by the given argument
+/// strategies.
+#[cfg(all(feature = "fixed", not(feature = "float")))]
+pub fn pid_controllers<T>(
+    proportional_gains: impl Strategy<Value = T>,
+    integral_time_constants: impl Strategy<Value = T>,
+    derivative_time_constants: impl Strategy<Value = T>,
+    set_point_coefficients: impl Strategy<Value = T>,
+    initial_controller_outputs: impl Strategy<Value = T>,
+) -> impl Strategy<Value = Result<PidController<T>, PidControllerError<T>>>
+where
+    T: Number + ArbInterop + Fixed + Debug,
+{
+    (
+        proportional_gains,
+        integral_time_constants,
+        derivative_time_constants,
+        set_point_coefficients,
+        initial_controller_outputs,
+    )
+        .prop_map(
+            |(
+                proportional_gain,
+                integral_time_constant,
+                derivative_time_constant,
+                set_point_coefficient,
+                initial_controller_output,
+            )| {
+                PidController::new(
+                    proportional_gain,
+                    integral_time_constant,
+                    derivative_time_constant,
+                    set_point_coefficient,
+                    initial_controller_output,
+                )
+            },
+        )
+}
+
+/// This strategy generates `PidController<T>` structs whose configuration
+/// parameters cover the entire permissible domain.
+#[cfg(all(feature = "float", not(feature = "fixed")))]
+pub fn default_pid_controllers<T>(
+) -> impl Strategy<Value = Result<PidController<T>, PidControllerError<T>>>
+where
+    T: Number + ArbInterop + Float + Debug,
+{
+    let zero = <T as Number>::zero();
+    let eps = <T as Number>::epsilon();
+    let max = <T as Number>::max_value();
+    pid_controllers(
+        bounded_numbers(zero, max),
+        bounded_numbers(eps, max),
+        bounded_numbers(eps, max),
+        bounded_numbers(zero, max),
+        bounded_numbers(-max, max),
+    )
+}
+
+/// This strategy generates `PidController<T>` structs whose configuration
+/// parameters cover the entire permissible domain.
+#[cfg(all(feature = "fixed", not(feature = "float")))]
+pub fn default_pid_controllers<T>(
+) -> impl Strategy<Value = Result<PidController<T>, PidControllerError<T>>>
+where
+    T: Number + ArbInterop + Fixed + Debug,
+{
+    let zero = <T as Number>::zero();
+    let eps = <T as Number>::epsilon();
+    let max = <T as Number>::max_value();
+    pid_controllers(
+        bounded_numbers(zero, max),
+        bounded_numbers(eps, max),
+        bounded_numbers(eps, max),
+        bounded_numbers(zero, max),
+        bounded_numbers(-max, max),
+    )
+}
+
+/// This strategy generates ordered pairs of timestamps `(before, after)`
+/// where `before` is guaranteed to be earlier than `after`.
+#[cfg(all(feature = "float", not(feature = "fixed")))]
+pub fn ordered_system_times() -> impl Strategy<Value = (SystemTime, SystemTime)> {
+    (any::<SystemTime>(), any::<i32>(), 1u32..1_000_000_000u32).prop_map(|(time, delta, nanos)| {
+        (
+            time,
+            time + Duration::new(delta.unsigned_abs() as u64, nanos),
+        )
+    })
+}
+
+/// This strategy generates ordered pairs of timestamps `(before, after)`
+/// where `before` is guaranteed to be earlier than `after`.
+#[cfg(all(feature = "fixed", not(feature = "float")))]
+pub fn ordered_system_times() -> impl Strategy<Value = (SystemTime, SystemTime)> {
+    (any::<SystemTime>(), any::<i32>(), 1u32..1_000_000_000u32).prop_map(|(time, delta, nanos)| {
+        (
+            time,
+            time + Duration::new(delta.unsigned_abs() as u64, nanos),
+        )
+    })
+}
+
+//
+// strategies tests
+//
+mod test {
+    use super::*;
+
+    proptest! {
+
+        #[cfg(all(feature = "float", not(feature = "fixed")))]
+        #[test]
+        fn bound_bounds_numbers(
+            (low, high) in ordered_pairs::<f64>(),
+            n in well_behaved_numbers::<f64>(),
+        ) {
+            let bounded = bound(low, high, n);
+
+            assert!(
+                bounded >= low,
+                "low: {:?} high: {:?} n: {:?} bounded: {:?} bounded must be >= low",
+                low, high, n, bounded,
+            );
+            assert!(
+                bounded <= high,
+                "low: {:?} high: {:?} n: {:?} bounded: {:?} bounded must be <= high",
+                low, high, n, bounded,
+            );
+        }
+
+        #[cfg(all(feature = "fixed", not(feature = "float")))]
+        #[test]
+        fn bound_bounds_numbers(
+            (low, high) in ordered_pairs::<I32F32>(),
+            n in well_behaved_numbers::<I32F32>(),
+        ) {
+            let bounded = bound(low, high, n);
+
+            assert!(
+                bounded >= low,
+                "low: {:?} high: {:?} n: {:?} bounded: {:?} bounded must be >= low",
+                low, high, n, bounded,
+            );
+            assert!(
+                bounded <= high,
+                "low: {:?} high: {:?} n: {:?} bounded: {:?} bounded must be <= high",
+                low, high, n, bounded,
+            );
+        }
+
+        #[cfg(all(feature = "float", not(feature = "fixed")))]
+        #[test]
+        fn well_behaved_numbers_behave_well(
+            n in well_behaved_numbers::<f64>(),
+        ) {
+            assert!(<f64 as Float>::is_finite(n));
+            assert!(!<f64 as Float>::is_nan(n));
+            assert!(!<f64 as Float>::is_infinite(n));
+        }
+
+        #[cfg(all(feature = "float", not(feature = "fixed")))]
+        #[test]
+        fn ordered_pairs_generates_ordered_numbers(
+            (low, high) in ordered_pairs::<f64>(),
+        ) {
+            assert!(
+                low < high,
+                "low: {:?} high: {:?} low must be < high",
+                low,
+                high
+            )
+        }
+
+        #[cfg(all(feature = "fixed", not(feature = "float")))]
+        #[test]
+        fn ordered_pairs_generates_ordered_numbers(
+            (low, high) in ordered_pairs::<I32F32>(),
+        ) {
+            assert!(
+                low < high,
+                "low: {:?} high: {:?} low must be < high",
+                low,
+                high
+            )
+        }
+
+        #[cfg(all(feature = "float", not(feature = "fixed")))]
+        #[test]
+        fn bounded_numbers_generates_numbers_on_interval(
+            (low, high, n) in arbitrary_bounded_numbers::<f64>(),
+        ) {
+            assert!(
+                n >= low,
+                "low: {:?} high: {:?} n: {:?} n must be >= low",
+                low,
+                high,
                 n
-            }
-        })
-        .prop_map(make_behave)
-}
-
-/// This strategy generates real numbers of type `T` on the interval
-/// `(T::epsilon(), 1 / T::epsilon()]`
-#[cfg(all(feature = "fixed", not(feature = "float")))]
-pub fn epsilon_epsilon_inverse_bounded_numbers<T>() -> impl Strategy<Value = T>
-where
-    T: Number + ArbInterop + Fixed + Debug,
-{
-    positive_nonzero_numbers::<T>().prop_map(|n: T| {
-        let one = <T as Number>::one();
-        let two = one + one;
-        let eps = <T as Number>::epsilon();
-        let max = (two * two * T::epsilon()).recip(); // FIXME: more rigor
-
-        if n > max {
-            let val = max * ((n.sin() + one) / two);
-
-            if val > eps {
-                val
-            } else {
-                eps
-            }
-        } else {
-            n
+            );
+            assert!(
+                n <= high,
+                "low: {:?} high: {:?} n: {:?} n must be <= high",
+                low,
+                high,
+                n
+            );
         }
-    })
-}
 
-/// This strategy generates real numbers of type `T` on the interval
-/// `[T::zero(), 1 / T::epsilon()]`
-#[cfg(all(feature = "float", not(feature = "fixed")))]
-pub fn zero_epsilon_inverse_bounded_numbers<T>() -> impl Strategy<Value = T>
-where
-    T: Number + ArbInterop + Float + Debug,
-{
-    well_behaved_numbers()
-        .prop_map(|n: T| {
-            let one = <T as Number>::one();
-            let two = one + one;
-            let max = one / (two * two * <T as Number>::epsilon()); // FIXME: more rigor
-
-            max * ((n.sin() + one) / two)
-        })
-        .prop_map(make_behave)
-}
-
-/// This strategy generates real numbers of type `T` on the interval
-/// `[T::zero(), 1 / T::epsilon()]`
-#[cfg(all(feature = "fixed", not(feature = "float")))]
-pub fn zero_epsilon_inverse_bounded_numbers<T>() -> impl Strategy<Value = T>
-where
-    T: Number + ArbInterop + Fixed + Debug,
-{
-    well_behaved_numbers().prop_map(|n: T| {
-        let one = <T as Number>::one();
-        let two = one + one;
-        let max = (two * two * T::epsilon()).recip(); // FIXME: more rigor
-
-        max * ((n.sin() + one) / two)
-    })
-}
-
-#[cfg(all(feature = "float", not(feature = "fixed")))]
-pub fn negative_epsilon_inverse_epsilon_inverse_bounded_numbers<T>() -> impl Strategy<Value = T>
-where
-    T: Number + ArbInterop + Float + Debug,
-{
-    arb::<T>()
-        .prop_map(|n| {
-            let one = <T as Number>::one();
-            let two = one + one;
-            let max = one / (two * two * <T as Number>::epsilon()); // FIXME: more rigor
-            max * n.cos()
-        })
-        .prop_map(make_behave)
-}
-
-#[cfg(all(feature = "fixed", not(feature = "float")))]
-pub fn negative_epsilon_inverse_epsilon_inverse_bounded_numbers<T>() -> impl Strategy<Value = T>
-where
-    T: Number + ArbInterop + Fixed + Debug,
-{
-    arb::<T>().prop_map(|n| {
-        let one = <T as Number>::one();
-        let two = one + one;
-        let max = (two * two * T::epsilon()).recip(); // FIXME: more rigor
-        max * n.cos()
-    })
-}
-
-/// This strategy generates `PidController<T>` structs whose configuration
-/// parameters are themselves individually populated by the given argument
-/// strategies.
-#[cfg(all(feature = "float", not(feature = "fixed")))]
-pub fn pid_controllers<T>(
-    proportional_gains: impl Strategy<Value = T>,
-    integral_time_constants: impl Strategy<Value = T>,
-    derivative_time_constants: impl Strategy<Value = T>,
-    set_point_coefficients: impl Strategy<Value = T>,
-    initial_controller_outputs: impl Strategy<Value = T>,
-) -> impl Strategy<Value = Result<PidController<T>, PidControllerError>>
-where
-    T: Number + ArbInterop + Float + Debug,
-{
-    (
-        proportional_gains,
-        integral_time_constants,
-        derivative_time_constants,
-        set_point_coefficients,
-        initial_controller_outputs,
-    )
-        .prop_map(
-            |(
-                proportional_gain,
-                integral_time_constant,
-                derivative_time_constant,
-                set_point_coefficient,
-                initial_controller_output,
-            )| {
-                PidController::new(
-                    proportional_gain,
-                    integral_time_constant,
-                    derivative_time_constant,
-                    set_point_coefficient,
-                    initial_controller_output,
-                )
-            },
-        )
-}
-
-/// This strategy generates `PidController<T>` structs whose configuration
-/// parameters are themselves individually populated by the given argument
-/// strategies.
-#[cfg(all(feature = "fixed", not(feature = "float")))]
-pub fn pid_controllers<T>(
-    proportional_gains: impl Strategy<Value = T>,
-    integral_time_constants: impl Strategy<Value = T>,
-    derivative_time_constants: impl Strategy<Value = T>,
-    set_point_coefficients: impl Strategy<Value = T>,
-    initial_controller_outputs: impl Strategy<Value = T>,
-) -> impl Strategy<Value = Result<PidController<T>, PidControllerError>>
-where
-    T: Number + ArbInterop + Fixed + Debug,
-{
-    (
-        proportional_gains,
-        integral_time_constants,
-        derivative_time_constants,
-        set_point_coefficients,
-        initial_controller_outputs,
-    )
-        .prop_map(
-            |(
-                proportional_gain,
-                integral_time_constant,
-                derivative_time_constant,
-                set_point_coefficient,
-                initial_controller_output,
-            )| {
-                PidController::new(
-                    proportional_gain,
-                    integral_time_constant,
-                    derivative_time_constant,
-                    set_point_coefficient,
-                    initial_controller_output,
-                )
-            },
-        )
-}
-
-/// This strategy generates `PidController<T>` structs whose configuration
-/// parameters cover the entire permissible domain.
-#[cfg(all(feature = "float", not(feature = "fixed")))]
-pub fn default_pid_controllers<T>(
-) -> impl Strategy<Value = Result<PidController<T>, PidControllerError>>
-where
-    T: Number + ArbInterop + Float + Debug,
-{
-    pid_controllers(
-        zero_epsilon_inverse_bounded_numbers(),
-        epsilon_epsilon_inverse_bounded_numbers(),
-        epsilon_epsilon_inverse_bounded_numbers(),
-        zero_epsilon_inverse_bounded_numbers(),
-        negative_epsilon_inverse_epsilon_inverse_bounded_numbers(),
-    )
-}
-
-/// This strategy generates `PidController<T>` structs whose configuration
-/// parameters cover the entire permissible domain.
-#[cfg(all(feature = "fixed", not(feature = "float")))]
-pub fn default_pid_controllers<T>(
-) -> impl Strategy<Value = Result<PidController<T>, PidControllerError>>
-where
-    T: Number + ArbInterop + Fixed + Debug,
-{
-    pid_controllers(
-        zero_epsilon_inverse_bounded_numbers(),
-        epsilon_epsilon_inverse_bounded_numbers(),
-        epsilon_epsilon_inverse_bounded_numbers(),
-        zero_epsilon_inverse_bounded_numbers(),
-        negative_epsilon_inverse_epsilon_inverse_bounded_numbers(),
-    )
-}
-
-/// This strategy generates ordered pairs of timestamps `(before, after)`
-/// where `before` is guaranteed to be earlier than `after`.
-#[cfg(all(feature = "float", not(feature = "fixed")))]
-pub fn ordered_system_times() -> impl Strategy<Value = (SystemTime, SystemTime)> {
-    (any::<SystemTime>(), any::<i32>(), 0u32..1_000_000_000u32).prop_map(|(time, delta, nanos)| {
-        (
-            time,
-            time + Duration::new(delta.unsigned_abs() as u64, nanos),
-        )
-    })
-}
-
-/// This strategy generates ordered pairs of timestamps `(before, after)`
-/// where `before` is guaranteed to be earlier than `after`.
-#[cfg(all(feature = "fixed", not(feature = "float")))]
-pub fn ordered_system_times() -> impl Strategy<Value = (SystemTime, SystemTime)> {
-    (any::<SystemTime>(), any::<i32>(), 0u32..1_000_000_000u32).prop_map(|(time, delta, nanos)| {
-        (
-            time,
-            time + Duration::new(delta.unsigned_abs() as u64, nanos),
-        )
-    })
+        #[cfg(all(feature = "fixed", not(feature = "float")))]
+        #[test]
+        fn bounded_numbers_generates_numbers_on_interval(
+            (low, high, n) in arbitrary_bounded_numbers::<I32F32>(),
+        ) {
+            assert!(
+                n >= low,
+                "low: {:?} high: {:?} n: {:?} n must be >= low",
+                low,
+                high,
+                n
+            );
+            assert!(
+                n <= high,
+                "low: {:?} high: {:?} n: {:?} n must be <= high",
+                low,
+                high,
+                n
+            );
+        }
+    }
 }


### PR DESCRIPTION
This PR adds optional fixed point math support via the [fixed](https://docs.rs/fixed/latest/fixed/index.html) and [cordic](https://docs.rs/cordic/latest/cordic/index.html) crates. This entails the addition of a `guv::Number` trait which we (optionally, given feature flags `"float"` or `"fixed"`) provide blanket implementations for types implementing `num_traits::float::Float` or `cordic::CordicNumber`.